### PR TITLE
docs: explain password use in schema > encryption

### DIFF
--- a/docs-src/rx-schema.md
+++ b/docs-src/rx-schema.md
@@ -210,6 +210,7 @@ const schemaWithFinalAge = {
 
 By adding a field to the `encrypted` list, it will be stored encrypted inside of the data-store. The encryption will run internally, so when you get the `RxDocument`, you can access the unencrypted value.
 You can set all fields to be encrypted, even nested objects. You can not run queries over encrypted fields.
+The password used for encryption is set during database creation. [See RxDatabase](./rx-database.md#password).
 
 ```js
 const schemaWithDefaultAge = {


### PR DESCRIPTION
New to RxDB / Pouch / Couch. Spent a few hours evaluating security considerations across each for an upcoming project. Password use for encryption isn't very clear in the current docs.

This commit provides a brief description and link to the relevant section in the database creation doc (which I stumbled across after the fact).

## This PR contains:
 - IMPROVED DOCS

## Describe the problem you have without this PR
Couldn't work out how encryption worked from the docs alone.